### PR TITLE
fixed workflow so that changes to aggregate_trips.py triggers rerun

### DIFF
--- a/workflow.yaml
+++ b/workflow.yaml
@@ -10,13 +10,13 @@ depends: data/Divvy_Stations_Trips_2013.zip
 command: 
    - unzip {{depends}} -d $(dirname {{depends}})
 ---
-creates: web/data/
-command: 
-   - mkdir -p {{creates}}
----
 creates: web/data/Station_Data.csv
-depends: data/Divvy_Stations_Trips_2013/
-command: python munge/aggregate_trips.py
+depends: 
+   - data/Divvy_Stations_Trips_2013/
+   - munge/aggregate_trips.py
+command: 
+   - mkdir -p $(dirname {{creates}})
+   - python {{depends}}
 ---
 creates: web/server_is_up
 depends: web/data/Station_Data.csv


### PR DESCRIPTION
Two recommendations here:
1. removed the web/data/ target as all it is doing is creating a directory. moved that to the first place where that directory is needed.
2. added the aggregate_trips.py script to the `depends` list so that any changes to that script would require things to be re-run. 
